### PR TITLE
feat: enhance markdown outputs with summary data

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ steps:
   - name: write to job summary
     run: |
       cat ${{ steps.convert-twistlock-results.outputs.summary-table }} >> $GITHUB_STEP_SUMMARY
-      echo "" >> $GITHUB_STEP_SUMMARY
       cat ${{ steps.convert-twistlock-results.outputs.vulnerability-table }} >> $GITHUB_STEP_SUMMARY
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -56,12 +56,15 @@ if (Array.isArray(obj.results) && obj.results.length > 0) {
       vulnerabilities: result.vulnerabilities,
     });
 
+    let vulnerabilitiesDetails = `## Twistlock Vulnerabilities (${result.vulnerabilities.length})\n`;
+    let markdownVulnerabilitiesWithDetails = `${vulnerabilitiesDetails}\n\n${markdownVulnerabilities}\n`;
+
     // log the Markdown vulnerabilities to the console
-    console.log(markdownVulnerabilities);
+    console.log(markdownVulnerabilitiesWithDetails);
 
     // write the Markdown vulnerabilities to a file
     const twistlockVulnerabilityTable = "./twistlock-vulnerability-table.md";
-    fs.writeFileSync(twistlockVulnerabilityTable, markdownVulnerabilities);
+    fs.writeFileSync(twistlockVulnerabilityTable, `${markdownVulnerabilitiesWithDetails}\n`);
     core.setOutput("vulnerability-table", twistlockVulnerabilityTable);
 
     // count the number of vulnerabilities with each severity
@@ -101,11 +104,19 @@ if (Array.isArray(obj.results) && obj.results.length > 0) {
     // var rows = Object.keys(severityCounts).map(severity => ({ Severity: severity, Count: severityCounts[severity] }));
 
     var markdownSummary = json2md({ table: { headers: headers, rows: rows } });
+
+    // add scan details to the summary table
+    let scanTime = new Date(obj.results[0].scanTime).toISOString().slice(0, 16).replace('T', ' ');
+    let scanId = obj.results[0].scanID;
+    let url = obj.consoleURL;
+    let summaryDetails = `## Twistlock Scan Summary\n\nScan: 💾 ${scanId} | 📅 ${scanTime} | 🔗 [More Details](${url})`;
+    let markdownSummaryWithDetails = `${summaryDetails}\n\n${markdownSummary}\n`;
+
     // log the Markdown table to the console
-    console.log(markdownSummary);
+    console.log(markdownSummaryWithDetails);
     // write the Markdown table to a file
     const twistlockSummaryTable = "./twistlock-summary-table.md";
-    fs.writeFileSync(twistlockSummaryTable, markdownSummary);
+    fs.writeFileSync(twistlockSummaryTable, markdownSummaryWithDetails);
     core.setOutput("summary-table", twistlockSummaryTable);
   }
 } else {


### PR DESCRIPTION
Added header and summary information, such as the scan ID, scan time, and link to results

<img width="1151" alt="image" src="https://github.com/joshjohanning/twistlock-results-json-to-markdown-action/assets/19912012/64e4e4bb-95a1-472c-be23-1756b440b974">

closes #1