### PR TITLE
Improvements for twistlock markdown action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,6 @@
 name: "Publish GitHub Action"
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ outputs:
   compliance-summary-table:
     description: "The compliance summary table in markdown format"
   compliance-table:
-    description: "The compliance  table in markdown format"
+    description: "The compliance table in markdown format"
 
 runs:
   using: "node20"

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ outputs:
     description: "The summary table in markdown format"
   vulnerability-table:
     description: "The vulnerabilities table in markdown format"
+  compliance-summary-table:
+    description: "The compliance summary table in markdown format"
+  compliance-table:
+    description: "The compliance  table in markdown format"
 
 runs:
   using: "node20"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "twistlock-results-json-to-markdown-action",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "twistlock-results-json-to-markdown-action",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "twistlock-results-json-to-markdown-action",
   "description": "Twistlock/Prisma Scan Results JSON to Markdown",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "",
   "private": true,
   "homepage": "https://github.com/joshjohanning/twistlock-results-json-to-markdown-action#readme",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "twistlock-results-json-to-markdown-action",
   "description": "Twistlock/Prisma Scan Results JSON to Markdown",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "",
   "private": true,
   "homepage": "https://github.com/joshjohanning/twistlock-results-json-to-markdown-action#readme",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "twistlock-results-json-to-markdown-action",
   "description": "Twistlock/Prisma Scan Results JSON to Markdown",
-  "version": "1.0.4",
+  "version": "1.0.3",
   "author": "",
   "private": true,
   "homepage": "https://github.com/joshjohanning/twistlock-results-json-to-markdown-action#readme",

--- a/src/index.js
+++ b/src/index.js
@@ -135,6 +135,16 @@ if (Array.isArray(obj.results) && obj.results.length > 0) {
     );
   }
 
+  // Define severity symbols
+  var severitySymbols = {
+    critical: "‼️",
+    important: "❌",
+    high: "⛔️",
+    medium: "⚠️",
+    moderate: "⚠️",
+    low: "🟡",
+  };
+
   // convert the complianceSeverityCounts object to a Markdown table
   var complianceHeaders = ["Severity", "Count"];
 
@@ -179,15 +189,6 @@ if (Array.isArray(obj.results) && obj.results.length > 0) {
 
   // convert the severityCounts object to a Markdown table
   var headers = ["Severity", "Count"];
-
-  var severitySymbols = {
-    critical: "‼️",
-    important: "❌",
-    high: "⛔️",
-    medium: "⚠️",
-    moderate: "⚠️",
-    low: "🟡",
-  };
 
   var rows = Object.keys(severityCounts).map((severity) => {
     var symbol = severitySymbols[severity] || "";


### PR DESCRIPTION
I added the following improvements:
- create empty tables if there are no findings (otherwise my subsequent steps were failing due to missing files)
- use the vulnerability summary from the json if it's available
- added compliance findings